### PR TITLE
Find spawner route using more durable class label than by route name

### DIFF
--- a/tasks/update-homeroom.yml
+++ b/tasks/update-homeroom.yml
@@ -9,8 +9,9 @@
   k8s_facts:
     api_version: "route.openshift.io/v1"
     kind: Route
-    name: "{{ workshop_app_name }}"
     namespace: "{{ project_name }}"
+    label_selectors:
+      - class = spawner
   register: __lab_route
 
 - name: Get lab route (value)


### PR DESCRIPTION

This, when coupled with a tag (say 0.1.1) and update to the [requirements.yml in the starter guides repo ](https://github.com/hatmarch/starter-guides/blob/784678f08e9fda54a32174bf28d2985ca35e328f/apb/requirements.yml) will fix the ocp-4.2 branches playbook for installing openshift starter lab on 4.2+ OpenShift instances